### PR TITLE
Beta beta

### DIFF
--- a/lib/misc/data.py
+++ b/lib/misc/data.py
@@ -213,3 +213,16 @@ def check_vars( _vars_, _varstype_, _endtext_ = 'Input script not created!'):
     
         
     return _flag_c_
+
+def isnot_num( _string_):
+    ''' return True if the string is not numeric
+    '''
+    _flag_ = True
+    try:
+        float( _string_)
+        _flag_ = False
+    except ValueError:
+        pass
+    return _flag_
+    
+# vim:tw=80


### PR DESCRIPTION
bug fixing
'' not isdigit do not recognize float, leading to unwanted behavior ''

isalnum puts true for alpha eg:
a = 'kjshf'; a.isalnum(); > True
isnumeric, to use it first you need to convert to proper UTF-8
isdecimal, in python 2.7 'str' object has no attribute 'isdecimal'

Therefore, more funny and straightforward: isnot_num implementation